### PR TITLE
Move global variable definition to source file

### DIFF
--- a/memcached_client/stats.c
+++ b/memcached_client/stats.c
@@ -10,6 +10,8 @@
 #include "worker.h"
 
 pthread_mutex_t stats_lock = PTHREAD_MUTEX_INITIALIZER;
+struct timeval start_time;
+struct memcached_stats global_stats;
 
 void addSample(struct stat* stat, float value) {
   stat->s0 += 1.0;

--- a/memcached_client/stats.h
+++ b/memcached_client/stats.h
@@ -22,7 +22,7 @@
 
 struct config;
 
-struct timeval start_time;
+extern struct timeval start_time;
 
 //A single statistic
 struct stat {
@@ -57,7 +57,7 @@ struct memcached_stats {
 
 extern pthread_mutex_t stats_lock;
 //For now, all statistics are handled by this global struct
-struct memcached_stats global_stats;
+extern struct memcached_stats global_stats;
 double findQuantile(struct stat* stat, double quantile);
 void printGlobalStats();
 void checkExit(struct config* config);


### PR DESCRIPTION
GCC 10 default enables `-fno-common` flag, so the global variable defined in the head file should be annotated with `extern` and its definition should be moved to the source file to avoid the multiple definition error. 